### PR TITLE
fixed bug for next video button on first video

### DIFF
--- a/script/youtube_iframe.js
+++ b/script/youtube_iframe.js
@@ -53,8 +53,12 @@ function playNextYTVideo() {
             setTimeout(function(){
                 next();
             }, 250)
+        }else if(currentVideoIndex == -1){
+            next()
         }
+
         else{
+            debugger
             $('.carousel').carousel('next')
             next();
         }


### PR DESCRIPTION
Notes from Meistertask:  When next video button is clicked, if nothing nothing is selected in current video list, page will go to the next page and plays the first video (should stay on first page and play first video)