### PR TITLE
hide tabel header on page load

### DIFF
--- a/script/youtube_iframe.js
+++ b/script/youtube_iframe.js
@@ -3,7 +3,7 @@ firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);//what is this?
 function onYouTubeIframeAPIReady(vidId) {
     console.log("onYouTubeIframeAPIReady CALLED", player);
     player = new YT.Player('mainVideo', {
-        videoId: vidId || 'lrzIR8seNXs',
+        videoId: vidId || 'rSBWaxEo-2k',
         playerVars: {
             'rel': 0
         },

--- a/style.css
+++ b/style.css
@@ -538,6 +538,10 @@ div.thRow {
 	z-index: 1;
 }
 
+.videoHeader {
+	display: none;
+}
+
 
 /*.tdChannel, .tdUpDate{*/
 	/*justify-content: center;*/


### PR DESCRIPTION
fixed bug that allowed table header to show on page load.

**Video table top/th row is visable when the page is loading - should be hidden**